### PR TITLE
refactor: replace raw string IDs with StrEnum constants

### DIFF
--- a/src/poe_copilot/constants.py
+++ b/src/poe_copilot/constants.py
@@ -1,6 +1,27 @@
-"""Centralized path constants for the poe_copilot package."""
+"""Centralized path and enum constants for the poe_copilot package."""
 
+from enum import StrEnum
 from pathlib import Path
+
+
+class League(StrEnum):
+    CHALLENGE = "challenge"
+    STANDARD = "standard"
+
+
+class GameMode(StrEnum):
+    SOFTCORE_TRADE = "softcore_trade"
+    HARDCORE_TRADE = "hardcore_trade"
+    SSF = "ssf"
+    HC_SSF = "hc_ssf"
+
+
+class Experience(StrEnum):
+    NEWBIE = "newbie"
+    CASUAL = "casual"
+    INTERMEDIATE = "intermediate"
+    VETERAN = "veteran"
+
 
 # Package root: src/poe_copilot/
 PACKAGE_DIR = Path(__file__).resolve().parent

--- a/src/poe_copilot/core/context.py
+++ b/src/poe_copilot/core/context.py
@@ -3,7 +3,7 @@
 import re
 from datetime import date
 
-from ..constants import AGENTS_DIR, TIMELINE_FILE
+from ..constants import AGENTS_DIR, TIMELINE_FILE, Experience, GameMode, League
 
 
 def _load_timeline() -> str:
@@ -88,10 +88,10 @@ def resolve_league(settings: dict) -> str:
     str
         Display-ready league name (e.g. ``"Standard"`` or ``"Mirage"``).
     """
-    raw = settings.get("league", "standard")
-    if raw == "standard":
+    raw = settings.get("league", League.STANDARD)
+    if raw == League.STANDARD:
         return "Standard"
-    if raw == "challenge":
+    if raw == League.CHALLENGE:
         entries = _parse_timeline()
         if entries:
             _, current_league, _ = _annotate_timeline(entries, date.today())
@@ -108,22 +108,22 @@ IDENTITY = (
 )
 
 MODE_CONTEXT = {
-    "softcore_trade": (
+    GameMode.SOFTCORE_TRADE: (
         "The player is in softcore trade league. Deaths are not permanent. "
         "They can trade freely, so gear recommendations can include trade purchases."
     ),
-    "hardcore_trade": (
+    GameMode.HARDCORE_TRADE: (
         "The player is in HARDCORE trade league. Death is permanent (character moves "
         "to Standard). ALWAYS prioritize survivability and defensive layers. Avoid "
         "recommending glass cannon builds. EHP and max hit taken matter enormously."
     ),
-    "ssf": (
+    GameMode.SSF: (
         "The player is in SSF (Solo Self-Found). They CANNOT trade with other players. "
         "All gear must be self-found or crafted. Avoid recommending builds that depend "
         "on specific unique items unless they are common drops or target-farmable. "
         "Favour builds that function well with rare gear and deterministic crafting."
     ),
-    "hc_ssf": (
+    GameMode.HC_SSF: (
         "The player is in HARDCORE SSF — the hardest mode. No trading AND permadeath. "
         "Only recommend extremely tanky, self-sufficient builds. Prioritize defenses "
         "above all else. Gear must be self-crafted. Avoid anything reliant on rare "
@@ -132,25 +132,25 @@ MODE_CONTEXT = {
 }
 
 EXP_CONTEXT = {
-    "newbie": (
+    Experience.NEWBIE: (
         "The player is NEW to Path of Exile. Explain concepts clearly and avoid "
         "unexplained jargon. When using PoE-specific terms, briefly define them. "
         "Suggest straightforward, beginner-friendly builds. Walk them through "
         "gearing and progression step by step. When they ask vague questions, "
         "guide them with 1-2 clarifying questions before diving in."
     ),
-    "casual": (
+    Experience.CASUAL: (
         "The player is a casual player with basic knowledge. They know core mechanics "
         "but may not be familiar with advanced crafting, atlas strategies, or "
         "min-maxing. Use common PoE terminology but clarify niche concepts. "
         "Ask for context when it would change your recommendation, but keep it brief."
     ),
-    "intermediate": (
+    Experience.INTERMEDIATE: (
         "The player is an intermediate player comfortable with endgame content. "
         "You can use standard PoE terminology freely. They understand atlas "
         "strategies, crafting basics, and build planning."
     ),
-    "veteran": (
+    Experience.VETERAN: (
         "The player is a veteran min-maxer. Skip basic explanations. Focus on "
         "optimization, edge cases, niche interactions, and advanced strategies. "
         "They appreciate precise numbers, breakpoints, and deep mechanical analysis. "
@@ -178,8 +178,8 @@ def build_player_context(settings: dict) -> str:
         Multi-section markdown context string.
     """
     league = resolve_league(settings)
-    mode = settings.get("mode", "softcore_trade")
-    experience = settings.get("experience", "intermediate")
+    mode = settings.get("mode", GameMode.SOFTCORE_TRADE)
+    experience = settings.get("experience", Experience.INTERMEDIATE)
 
     parts: list[str] = []
 

--- a/src/poe_copilot/onboarding.py
+++ b/src/poe_copilot/onboarding.py
@@ -5,21 +5,21 @@ import json
 from rich.console import Console
 from rich.prompt import Prompt
 
-from .constants import SETTINGS_DIR, SETTINGS_FILE
+from .constants import SETTINGS_DIR, SETTINGS_FILE, Experience, GameMode, League
 from .core.context import resolve_league
 
 MODES = {
-    "1": ("softcore_trade", "Softcore Trade"),
-    "2": ("hardcore_trade", "Hardcore Trade"),
-    "3": ("ssf", "Solo Self-Found (SSF)"),
-    "4": ("hc_ssf", "Hardcore SSF"),
+    "1": (GameMode.SOFTCORE_TRADE, "Softcore Trade"),
+    "2": (GameMode.HARDCORE_TRADE, "Hardcore Trade"),
+    "3": (GameMode.SSF, "Solo Self-Found (SSF)"),
+    "4": (GameMode.HC_SSF, "Hardcore SSF"),
 }
 
 EXPERIENCE = {
-    "1": ("newbie", "New player — still learning the ropes"),
-    "2": ("casual", "Casual — know the basics, played a few leagues"),
-    "3": ("intermediate", "Intermediate — comfortable with endgame"),
-    "4": ("veteran", "Veteran — deep knowledge, min-maxing"),
+    "1": (Experience.NEWBIE, "New player — still learning the ropes"),
+    "2": (Experience.CASUAL, "Casual — know the basics, played a few leagues"),
+    "3": (Experience.INTERMEDIATE, "Intermediate — comfortable with endgame"),
+    "4": (Experience.VETERAN, "Veteran — deep knowledge, min-maxing"),
 }
 
 
@@ -95,7 +95,7 @@ def run_onboarding(existing: dict | None = None) -> dict:
     console.print("   [1] League (current challenge league)")
     console.print("   [2] Standard")
     league_key = Prompt.ask("   Choice [1/2]", choices=["1", "2"], default="1")
-    league = "challenge" if league_key == "1" else "standard"
+    league = League.CHALLENGE if league_key == "1" else League.STANDARD
 
     # --- Mode ---
     console.print("\n[bold]3. Game mode?[/bold]")


### PR DESCRIPTION
## Summary
- Add `League`, `GameMode`, and `Experience` `StrEnum` classes to `constants.py`, centralizing string IDs that were previously scattered as raw literals
- Propagate enum usage to `onboarding.py` (menu dicts, league assignment) and `context.py` (dict keys, `resolve_league()`, default fallbacks)
- No changes needed in `__main__.py` — `StrEnum` values print as plain strings

## Test plan
- [x] `mypy src/` passes with no new errors
- [ ] `python -m poe_copilot --setup` onboarding wizard works identically
- [ ] Existing `~/.poechat/settings.usr` files load without issues (string values match enum values)

🤖 Generated with [Claude Code](https://claude.com/claude-code)