### PR TITLE
refactor: extract magic numbers to config module

### DIFF
--- a/src/poe_copilot/config.py
+++ b/src/poe_copilot/config.py
@@ -1,0 +1,39 @@
+"""Configuration constants for the poe_copilot package.
+
+This module centralizes magic numbers that were previously scattered
+throughout the codebase. These values control API limits, timeouts,
+truncation lengths, and other tunable parameters.
+"""
+
+# API Configuration
+DEFAULT_MAX_API_CALLS = 25
+DEFAULT_MAX_TOKENS = 4096
+HTTP_REQUEST_TIMEOUT = 15
+POE_NINJA_TIMEOUT = 10
+
+# Content Length Limits
+MAX_WEB_CONTENT_CHARS = 6000
+MAX_WEB_INTRO_CHARS = 2000
+MAX_LOG_PREVIEW_CHARS = 500
+MAX_DELEGATION_RESULT_CHARS = 2000
+MAX_PARTIAL_RESULT_CHARS = 2000
+
+# Message History Limits
+ASSISTANT_MESSAGE_CHAR_LIMIT = 1500
+USER_MESSAGE_CHAR_LIMIT = 300
+MAX_RESEARCH_ITEMS_FOR_ANSWER = 20
+
+# UI Display Truncation
+TRUNCATE_SECTION_CHARS = 25
+TRUNCATE_SHORT_URL_CHARS = 30
+TRUNCATE_LONG_URL_CHARS = 45
+TRUNCATE_QUERY_CHARS = 45
+TRUNCATE_NAME_FILTER_CHARS = 30
+TRUNCATE_ITEM_TYPE_CHARS = 30
+
+# Time Display
+SECONDS_PER_MINUTE = 60
+
+# poe.ninja API Limits
+POE_NINJA_MAX_RESULTS = 50
+POE_NINJA_MAX_BUILD_META_RESULTS = 15

--- a/src/poe_copilot/core/cli.py
+++ b/src/poe_copilot/core/cli.py
@@ -12,6 +12,15 @@ from rich.live import Live
 from rich.prompt import Prompt
 from rich.spinner import Spinner
 
+from poe_copilot.config import (
+    SECONDS_PER_MINUTE,
+    TRUNCATE_ITEM_TYPE_CHARS,
+    TRUNCATE_LONG_URL_CHARS,
+    TRUNCATE_NAME_FILTER_CHARS,
+    TRUNCATE_QUERY_CHARS,
+    TRUNCATE_SECTION_CHARS,
+    TRUNCATE_SHORT_URL_CHARS,
+)
 from poe_copilot.constants import LOGS_DIR
 from poe_copilot.core.agent import ClarifyingQuestion
 
@@ -49,22 +58,22 @@ def tool_status_label(name: str, tool_input: dict) -> str:
         section = tool_input.get("section", "")
         short_url = url.replace("https://", "").replace("http://", "")
         if section:
-            return f'Reading "{truncate(section, 25)}" from {truncate(short_url, 30)}'
-        return f"Reading {truncate(short_url, 45)}"
+            return f'Reading "{truncate(section, TRUNCATE_SECTION_CHARS)}" from {truncate(short_url, TRUNCATE_SHORT_URL_CHARS)}'
+        return f"Reading {truncate(short_url, TRUNCATE_LONG_URL_CHARS)}"
 
     if name == "poe_web_search":
         query = tool_input.get("query", "")
         if query:
-            return f"Searching: {truncate(query, 45)}"
+            return f"Searching: {truncate(query, TRUNCATE_QUERY_CHARS)}"
         return "Searching the web..."
 
     if name == "get_item_prices":
         name_filter = tool_input.get("name", "")
         item_type = tool_input.get("type", "")
         if name_filter:
-            return f'Looking up "{truncate(name_filter, 30)}" prices...'
+            return f'Looking up "{truncate(name_filter, TRUNCATE_NAME_FILTER_CHARS)}" prices...'
         if item_type:
-            return f"Looking up {truncate(item_type, 30)} prices..."
+            return f"Looking up {truncate(item_type, TRUNCATE_ITEM_TYPE_CHARS)} prices..."
         return "Looking up item prices..."
 
     if name == "get_build_meta":
@@ -128,8 +137,8 @@ class TimedSpinner:
             Spinner renderables with elapsed-time annotation.
         """
         elapsed = int(time.monotonic() - self._start)
-        if elapsed >= 60:
-            time_str = f"{elapsed // 60}m {elapsed % 60:02d}s"
+        if elapsed >= SECONDS_PER_MINUTE:
+            time_str = f"{elapsed // SECONDS_PER_MINUTE}m {elapsed % SECONDS_PER_MINUTE:02d}s"
         else:
             time_str = f"{elapsed}s"
         self._spinner.update(text=f"{self._text}  [dim]{time_str}[/dim]")

--- a/src/poe_copilot/core/orchestrator.py
+++ b/src/poe_copilot/core/orchestrator.py
@@ -198,7 +198,9 @@ class Orchestrator:
             self._on_status("Writing response...")
 
         research_summary = (
-            "\n".join(self._accumulated_research[-MAX_RESEARCH_ITEMS_FOR_ANSWER:])
+            "\n".join(
+                self._accumulated_research[-MAX_RESEARCH_ITEMS_FOR_ANSWER:]
+            )
             if self._accumulated_research
             else "(no research collected)"
         )
@@ -310,7 +312,9 @@ class Orchestrator:
                     logger.warning(
                         "Budget exceeded during delegation, returning partial results"
                     )
-                    partial = "\n".join(r["content"][:MAX_PARTIAL_RESULT_CHARS] for r in results)
+                    partial = "\n".join(
+                        r["content"][:MAX_PARTIAL_RESULT_CHARS] for r in results
+                    )
                     return f"(partial results — budget exceeded)\n{partial}"
 
                 if on_status:
@@ -446,7 +450,11 @@ class Orchestrator:
                         text_parts.append(block.text)  # type: ignore
                 content = " ".join(text_parts)
             if content and isinstance(content, str):
-                limit = ASSISTANT_MESSAGE_CHAR_LIMIT if role == "assistant" else USER_MESSAGE_CHAR_LIMIT
+                limit = (
+                    ASSISTANT_MESSAGE_CHAR_LIMIT
+                    if role == "assistant"
+                    else USER_MESSAGE_CHAR_LIMIT
+                )
                 context_parts.append(f"{role}: {content[:limit]}")
 
         context_str = (

--- a/src/poe_copilot/core/orchestrator.py
+++ b/src/poe_copilot/core/orchestrator.py
@@ -6,6 +6,16 @@ from typing import Callable, Optional
 
 import anthropic
 
+from poe_copilot.config import (
+    ASSISTANT_MESSAGE_CHAR_LIMIT,
+    DEFAULT_MAX_API_CALLS,
+    DEFAULT_MAX_TOKENS,
+    MAX_DELEGATION_RESULT_CHARS,
+    MAX_LOG_PREVIEW_CHARS,
+    MAX_PARTIAL_RESULT_CHARS,
+    MAX_RESEARCH_ITEMS_FOR_ANSWER,
+    USER_MESSAGE_CHAR_LIMIT,
+)
 from poe_copilot.constants import REGISTRY_FILE
 from poe_copilot.tools import _HANDLERS, TOOL_DEFINITIONS
 
@@ -35,7 +45,7 @@ class Orchestrator:
         self.settings = settings
         self.messages: list[dict] = []
         self.api_calls = 0
-        self.max_api_calls = 25
+        self.max_api_calls = DEFAULT_MAX_API_CALLS
         self._accumulated_research: list[str] = []
         self._conversation_context: str = ""
         self._on_status: Optional[Callable[[str], None]] = None
@@ -61,7 +71,7 @@ class Orchestrator:
                 model=cfg["model"],
                 tools=tools,
                 next_agent=cfg.get("next"),
-                max_tokens=cfg.get("max_tokens", 4096),
+                max_tokens=cfg.get("max_tokens", DEFAULT_MAX_TOKENS),
                 client=client,
             )
 
@@ -157,7 +167,7 @@ class Orchestrator:
                 return self._parse_clarification(decision.input["clarification"])  # type: ignore
 
         answer_text: str = decision.input["text"]  # type: ignore
-        logger.info("ANSWER: %s", answer_text[:500])
+        logger.info("ANSWER: %s", answer_text[:MAX_LOG_PREVIEW_CHARS])
         self.messages.append({"role": "assistant", "content": answer_text})
         return answer_text
 
@@ -178,7 +188,7 @@ class Orchestrator:
         """
         result = self._force_answerer(extra_context)
         answer_text: str = result.input["text"]
-        logger.info("FORCE_ANSWER: %s", answer_text[:500])
+        logger.info("FORCE_ANSWER: %s", answer_text[:MAX_LOG_PREVIEW_CHARS])
         self.messages.append({"role": "assistant", "content": answer_text})
         return answer_text
 
@@ -188,7 +198,7 @@ class Orchestrator:
             self._on_status("Writing response...")
 
         research_summary = (
-            "\n".join(self._accumulated_research[-20:])
+            "\n".join(self._accumulated_research[-MAX_RESEARCH_ITEMS_FOR_ANSWER:])
             if self._accumulated_research
             else "(no research collected)"
         )
@@ -290,7 +300,7 @@ class Orchestrator:
                         {"tool_use_id": tc["id"], "content": delegation_result}
                     )
                     self._accumulated_research.append(
-                        f"[{tc['name']}] {delegation_result[:2000]}"
+                        f"[{tc['name']}] {delegation_result[:MAX_DELEGATION_RESULT_CHARS]}"
                     )
 
                 results.extend(self._execute_tool_calls(regular_calls))
@@ -300,7 +310,7 @@ class Orchestrator:
                     logger.warning(
                         "Budget exceeded during delegation, returning partial results"
                     )
-                    partial = "\n".join(r["content"][:2000] for r in results)
+                    partial = "\n".join(r["content"][:MAX_PARTIAL_RESULT_CHARS] for r in results)
                     return f"(partial results — budget exceeded)\n{partial}"
 
                 if on_status:
@@ -378,7 +388,7 @@ class Orchestrator:
             )
             results.append({"tool_use_id": tc["id"], "content": result_content})
             self._accumulated_research.append(
-                f"[{tc['name']}] {result_content[:2000]}"
+                f"[{tc['name']}] {result_content[:MAX_DELEGATION_RESULT_CHARS]}"
             )
         return results
 
@@ -436,7 +446,7 @@ class Orchestrator:
                         text_parts.append(block.text)  # type: ignore
                 content = " ".join(text_parts)
             if content and isinstance(content, str):
-                limit = 1500 if role == "assistant" else 300
+                limit = ASSISTANT_MESSAGE_CHAR_LIMIT if role == "assistant" else USER_MESSAGE_CHAR_LIMIT
                 context_parts.append(f"{role}: {content[:limit]}")
 
         context_str = (

--- a/src/poe_copilot/tools/poe_ninja.py
+++ b/src/poe_copilot/tools/poe_ninja.py
@@ -134,7 +134,9 @@ MAX_BUILD_META_RESULTS = POE_NINJA_MAX_BUILD_META_RESULTS
 
 def _fetch(endpoint: str, params: dict) -> dict:
     """Send a GET request to the poe.ninja API and return the JSON response."""
-    with httpx.Client(timeout=POE_NINJA_TIMEOUT, follow_redirects=True) as client:
+    with httpx.Client(
+        timeout=POE_NINJA_TIMEOUT, follow_redirects=True
+    ) as client:
         resp = client.get(f"{BASE_URL}/{endpoint}", params=params)
         resp.raise_for_status()
         data = resp.json()

--- a/src/poe_copilot/tools/poe_ninja.py
+++ b/src/poe_copilot/tools/poe_ninja.py
@@ -2,6 +2,12 @@
 
 import httpx
 
+from poe_copilot.config import (
+    POE_NINJA_MAX_BUILD_META_RESULTS,
+    POE_NINJA_MAX_RESULTS,
+    POE_NINJA_TIMEOUT,
+)
+
 BASE_URL = "https://poe.ninja/api/data"
 
 CURRENCY_TYPES = ["Currency", "Fragment"]
@@ -122,13 +128,13 @@ POE_NINJA_TOOLS = [
 ]
 
 # Cap results sent to the LLM to avoid blowing up context
-MAX_RESULTS = 50
-MAX_BUILD_META_RESULTS = 15
+MAX_RESULTS = POE_NINJA_MAX_RESULTS
+MAX_BUILD_META_RESULTS = POE_NINJA_MAX_BUILD_META_RESULTS
 
 
 def _fetch(endpoint: str, params: dict) -> dict:
     """Send a GET request to the poe.ninja API and return the JSON response."""
-    with httpx.Client(timeout=10, follow_redirects=True) as client:
+    with httpx.Client(timeout=POE_NINJA_TIMEOUT, follow_redirects=True) as client:
         resp = client.get(f"{BASE_URL}/{endpoint}", params=params)
         resp.raise_for_status()
         data = resp.json()

--- a/src/poe_copilot/tools/web.py
+++ b/src/poe_copilot/tools/web.py
@@ -6,8 +6,12 @@ import httpx
 from bs4 import BeautifulSoup, Tag
 from ddgs import DDGS
 
-MAX_CONTENT_CHARS = 6000
-MAX_INTRO_CHARS = 2000
+from poe_copilot.config import (
+    HTTP_REQUEST_TIMEOUT,
+    MAX_WEB_CONTENT_CHARS,
+    MAX_WEB_INTRO_CHARS,
+)
+
 MAX_RESULTS = 8
 
 # Tags whose content is noise rather than article text
@@ -164,8 +168,8 @@ def _extract_section(soup: BeautifulSoup, section_query: str) -> str | None:
             parts.append(text)
 
     content = "\n".join(parts)
-    if len(content) > MAX_CONTENT_CHARS:
-        content = content[:MAX_CONTENT_CHARS] + "\n\n[... content truncated]"
+    if len(content) > MAX_WEB_CONTENT_CHARS:
+        content = content[:MAX_WEB_CONTENT_CHARS] + "\n\n[... content truncated]"
     return content
 
 
@@ -180,7 +184,7 @@ def _read_page(url: str, section: str | None = None) -> dict:
     """Fetch a webpage and return its outline or a targeted section."""
     try:
         with httpx.Client(
-            timeout=15,
+            timeout=HTTP_REQUEST_TIMEOUT,
             follow_redirects=True,
             headers={
                 "User-Agent": (
@@ -224,8 +228,8 @@ def _read_page(url: str, section: str | None = None) -> dict:
             section_names = [h["text"] for h in toc]
 
             body = _get_body_text(soup)
-            intro = body[:MAX_INTRO_CHARS]
-            if len(body) > MAX_INTRO_CHARS:
+            intro = body[:MAX_WEB_INTRO_CHARS]
+            if len(body) > MAX_WEB_INTRO_CHARS:
                 intro += (
                     "\n\n[... use section parameter to read specific sections]"
                 )


### PR DESCRIPTION
Fixes #9

## Summary

Centralized all magic numbers into a new  module for better maintainability and configurability.

## Changes

**New file:**
-  - Centralized configuration constants with descriptive names and documentation

**Modified files:**
-  - API budgets, token limits, content truncation
-  - UI display truncation, time formatting
-  - HTTP timeouts, content length limits
-  - API timeout, result limits

## Categories of constants extracted:

1. **API Configuration** - max_api_calls, max_tokens, timeouts
2. **Content Length Limits** - web content, log previews, delegation results
3. **Message History Limits** - assistant/user message truncation
4. **UI Display Truncation** - section names, URLs, queries
5. **poe.ninja API Limits** - max results, timeout

## Benefits:

- ✅ All tunable values in one place
- ✅ Self-documenting with clear constant names
- ✅ Easier to adjust behavior without hunting through code
- ✅ No functional changes - purely refactoring